### PR TITLE
Changed 'compile' for 'implementation'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,5 +25,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.6'
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '5.1.6'
 }


### PR DESCRIPTION
'compile' is going to be deprecated at the end of 2018